### PR TITLE
Fix parse and infer errors

### DIFF
--- a/src/constraint_solver.rs
+++ b/src/constraint_solver.rs
@@ -13,33 +13,25 @@ type Unifier = (Subst, Vec<Constraint>);
 pub fn run_solve(cs: &[Constraint], ctx: &Context) -> Subst {
     let empty_subst = Subst::new();
 
+    // TODO: normalize the result so that type params start at a1
     solver((empty_subst, cs.to_vec()), ctx)
 }
 
 fn solver(u: Unifier, ctx: &Context) -> Subst {
     let (su, cs) = u;
 
-    // println!("constraints:");
-    // for Constraint { types: (left, right) } in cs.iter() {
-    //     println!("{left} = {right}");
-    // }
-    // println!("subsitutions:");
-    // for (id, ty) in su.iter() {
-    //     println!("{id} -> {ty}");
-    // }
-
     if cs.is_empty() {
         return su;
     }
 
     let rest = &cs[1..]; // const [_ , ...rest] = cs;
-    rest.iter();
 
     match cs.get(0) {
         Some(c) => {
+            // su1 represents new substitutions from unifying the first constraint in cs.
             let su1 = unifies(c, ctx);
-            // TODO: can we create an impl of Substitutable for slices (or iterators)?
-            // TODO: implement ftv() and apply() on Vec<Constraint>
+            // This is applied to the remaining constraints (rest).  compose_subs is used
+            // to apply su1 to the HashMap of subsitutions, su.
             let unifier: Unifier = (compose_subs(&su1, &su), Vec::from(rest).apply(&su1));
             solver(unifier, ctx)
         }

--- a/src/constraint_solver.rs
+++ b/src/constraint_solver.rs
@@ -19,6 +19,15 @@ pub fn run_solve(cs: &[Constraint], ctx: &Context) -> Subst {
 fn solver(u: Unifier, ctx: &Context) -> Subst {
     let (su, cs) = u;
 
+    // println!("constraints:");
+    // for Constraint { types: (left, right) } in cs.iter() {
+    //     println!("{left} = {right}");
+    // }
+    // println!("subsitutions:");
+    // for (id, ty) in su.iter() {
+    //     println!("{id} -> {ty}");
+    // }
+
     if cs.is_empty() {
         return su;
     }
@@ -31,7 +40,7 @@ fn solver(u: Unifier, ctx: &Context) -> Subst {
             let su1 = unifies(c, ctx);
             // TODO: can we create an impl of Substitutable for slices (or iterators)?
             // TODO: implement ftv() and apply() on Vec<Constraint>
-            let unifier: Unifier = (compose_subs(&su1, &su), Vec::from(rest).apply(&su));
+            let unifier: Unifier = (compose_subs(&su1, &su), Vec::from(rest).apply(&su1));
             solver(unifier, ctx)
         }
         None => su,
@@ -65,6 +74,8 @@ fn unifies(c: &Constraint, ctx: &Context) -> Subst {
 }
 
 fn unify_lams(t1: &TLam, t2: &TLam, ctx: &Context) -> Subst {
+    // println!("unify_lams");
+    // println!("t1 = {t1}, t2 = {t2}");
     // TODO:
     // - varargs
     // - subtyping
@@ -109,6 +120,10 @@ fn unify_lams(t1: &TLam, t2: &TLam, ctx: &Context) -> Subst {
 }
 
 fn unify_many(cs: &[Constraint], ctx: &Context) -> Subst {
+    // println!("rununify_many_solve:");
+    // for Constraint { types: (left, right) } in cs {
+    //     println!("{left} = {right}");
+    // }
     match cs {
         [head, tail @ ..] => {
             let su_1 = unifies(head, ctx);

--- a/src/constraint_solver.rs
+++ b/src/constraint_solver.rs
@@ -13,7 +13,6 @@ type Unifier = (Subst, Vec<Constraint>);
 pub fn run_solve(cs: &[Constraint], ctx: &Context) -> Subst {
     let empty_subst = Subst::new();
 
-    // TODO: normalize the result so that type params start at a1
     solver((empty_subst, cs.to_vec()), ctx)
 }
 
@@ -38,6 +37,7 @@ fn solver(u: Unifier, ctx: &Context) -> Subst {
         None => su,
     }
 }
+
 fn compose_subs(s1: &Subst, s2: &Subst) -> Subst {
     let mut result: Subst = s2.iter().map(|(id, tv)| (*id, tv.apply(s1))).collect();
     result.extend(s1.to_owned());

--- a/src/constraint_solver.rs
+++ b/src/constraint_solver.rs
@@ -66,8 +66,6 @@ fn unifies(c: &Constraint, ctx: &Context) -> Subst {
 }
 
 fn unify_lams(t1: &TLam, t2: &TLam, ctx: &Context) -> Subst {
-    // println!("unify_lams");
-    // println!("t1 = {t1}, t2 = {t2}");
     // TODO:
     // - varargs
     // - subtyping
@@ -112,10 +110,6 @@ fn unify_lams(t1: &TLam, t2: &TLam, ctx: &Context) -> Subst {
 }
 
 fn unify_many(cs: &[Constraint], ctx: &Context) -> Subst {
-    // println!("rununify_many_solve:");
-    // for Constraint { types: (left, right) } in cs {
-    //     println!("{left} = {right}");
-    // }
     match cs {
         [head, tail @ ..] => {
             let su_1 = unifies(head, ctx);

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -92,18 +92,18 @@ use crate::syntax::{BindingIdent, Expr, WithSpan, Pattern, Statement, Program};
 // TODO: We need multiple Envs so that we can control things at differen scopes
 // e.g. global, module, function, ...
 pub fn infer_prog(env: Env, prog: &Program) -> Env {
-    let mut out_env: Env = Env::new();
+    let mut out_env: Env = env.clone();
 
     for (stmt, _span) in &prog.body {
         match stmt {
             Statement::Decl { pattern: (Pattern::Ident { name }, _span), value } => {
-                let scheme = infer_expr(env.clone(), value);
+                let scheme = infer_expr(out_env.clone(), value);
                 out_env.insert(name.to_owned(), scheme);
             },
             Statement::Expr(expr) => {
                 // We ignore the type that was inferred, we only care that
                 // it succeeds since we aren't assigning it to variable.
-                infer_expr(env.clone(), expr);
+                infer_expr(out_env.clone(), expr);
             },
         };
     }

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -92,48 +92,61 @@ use crate::syntax::{BindingIdent, Expr, WithSpan, Pattern, Statement, Program};
 // TODO: We need multiple Envs so that we can control things at differen scopes
 // e.g. global, module, function, ...
 pub fn infer_prog(env: Env, prog: &Program) -> Env {
-    let mut out_env: Env = env.clone();
+    let out_env: Env = env.clone();
+    let mut ctx: Context = Context::from(out_env);
 
     for (stmt, _span) in &prog.body {
         match stmt {
             Statement::Decl { pattern: (Pattern::Ident { name }, _span), value } => {
-                let scheme = infer_expr(out_env.clone(), value);
-                out_env.insert(name.to_owned(), scheme);
+                let scheme = infer_expr(&ctx, value);
+                ctx.env.insert(name.to_owned(), scheme);
+                // out_env.insert(name.to_owned(), scheme);
             },
             Statement::Expr(expr) => {
                 // We ignore the type that was inferred, we only care that
                 // it succeeds since we aren't assigning it to variable.
-                infer_expr(out_env.clone(), expr);
+                infer_expr(&ctx, expr);
             },
         };
     }
 
-    out_env
+    ctx.env
 }
 
-pub fn infer_stmt(env: Env, stmt: &WithSpan<Statement>) -> Scheme {
+pub fn infer_stmt(ctx: &Context, stmt: &WithSpan<Statement>) -> Scheme {
     match stmt {
-        (Statement::Expr(e), _) => infer_expr(env, e),
+        (Statement::Expr(e), _) => infer_expr(ctx, e),
         _ => panic!("We can't infer decls yet"),
     }
 }
 
-pub fn infer_expr(env: Env, expr: &WithSpan<Expr>) -> Scheme {
-    let init_ctx = Context::from(env);
-    let (ty, cs) = infer(expr, &init_ctx);
-    let subs = run_solve(&cs, &init_ctx);
+pub fn infer_expr(ctx: &Context, expr: &WithSpan<Expr>) -> Scheme {
+    // TODO: don't create a new Context each time
+    // let init_ctx = Context::from(env);
+    let (ty, cs) = infer(expr, ctx);
+    let subs = run_solve(&cs, ctx);
 
     close_over(&ty.apply(&subs))
 }
 
 fn close_over(ty: &Type) -> Scheme {
     let empty_env = Env::new();
-    generalize(&empty_env, ty)
+    // TODO: normalize the result so that type params start at a1
+    normalize(&generalize(&empty_env, ty))
+}
+
+fn normalize(sc: &Scheme) -> Scheme {
+    // TODO: implement this
+    sc.to_owned()
 }
 
 fn generalize(env: &Env, ty: &Type) -> Scheme {
+    // ftv() returns a Set which is not ordered
+    // TODO: switch to an ordered set
+    let mut qualifiers: Vec<_> = ty.ftv().difference(&env.ftv()).cloned().collect();
+    qualifiers.sort();
     Scheme {
-        qualifiers: ty.ftv().difference(&env.ftv()).cloned().collect(),
+        qualifiers,
         ty: ty.clone(),
     }
 }
@@ -185,6 +198,8 @@ fn infer(expr: &WithSpan<Expr>, ctx: &Context) -> InferResult {
                 };
             }
             let (ret_ty, cs) = infer(body, &new_ctx);
+            // // Update the count
+            // ctx.state.count.set(new_ctx.state.count.get());
             let lam_ty = Type::Lam(TLam {
                 args: arg_tvs,
                 ret: Box::new(ret_ty),
@@ -204,7 +219,8 @@ fn infer(expr: &WithSpan<Expr>, ctx: &Context) -> InferResult {
             let subs = run_solve(&cs1, &ctx);
             let (new_ctx, new_cs) = infer_pattern(pattern, &t1, &subs, ctx);
             let (t2, cs2) = infer(body, &new_ctx);
-
+            // // Update the count
+            // ctx.state.count.set(new_ctx.state.count.get());
             let mut cs: Vec<Constraint> = Vec::new();
             cs.extend(cs1);
             cs.extend(new_cs);

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,27 +3,22 @@ use std::collections::HashMap;
 
 use crochet::parser::*;
 use crochet::lexer::*;
-use crochet::context::Env;
+use crochet::context::{Context, Env};
 use crochet::infer::*;
 
 fn main() {
     println!("Hello, world!");
 
     let env: Env = HashMap::new();
+    let ctx = Context::from(env);
     let result = lexer().parse("5 + 10").unwrap();
     let spans: Vec<_> = result.iter().map(|(_, s)| s.to_owned()).collect();
     let tokens: Vec<_> = result.iter().map(|(t, _)| t.to_owned()).collect();
     let prog = token_parser(&spans).parse(tokens).unwrap();
     let stmt = prog.body.get(0).unwrap();
-    let result = infer_stmt(env, &stmt);
+    let result = infer_stmt(&ctx, &stmt);
 
     assert_eq!(format!("{}", result), "number");
-
-    // let result = lexer().parse("let x = 5 in x").unwrap();
-    // let spans: Vec<_> = result.iter().map(|(_, s)| s.to_owned()).collect();
-    // let tokens: Vec<_> = result.iter().map(|(t, _)| t.to_owned()).collect();
-    // let ast = token_parser(&spans).parse(tokens).unwrap();
-    // println!("ast = {:?}", ast);
 
     let foo = "var add = (a, b => {\na + b\n};";
     println!("foo = {}", foo);

--- a/src/substitutable.rs
+++ b/src/substitutable.rs
@@ -7,5 +7,6 @@ pub type Subst = HashMap<i32, Type>;
 
 pub trait Substitutable {
     fn apply(&self, subs: &Subst) -> Self;
+    // TODO: use an ordered set
     fn ftv(&self) -> HashSet<TVar>;
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -37,7 +37,7 @@ impl fmt::Display for Primitive {
 //     ty: Type,
 // }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialOrd, Ord)]
 pub struct TVar {
     pub id: i32,
     pub name: String,
@@ -145,7 +145,9 @@ impl fmt::Display for Scheme {
         if qualifiers.is_empty() {
             write!(f, "{}", ty)
         } else {
-            write!(f, "<{}>{}", join(qualifiers, ", "), ty)
+            let mut quals = qualifiers.clone();
+            quals.sort();
+            write!(f, "<{}>{}", join(quals, ", "), ty)
         }
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,7 +2,7 @@ use chumsky::prelude::*;
 use std::collections::HashMap;
 
 use crochet::context::Env;
-use crochet::infer::{infer_stmt, infer_prog};
+use crochet::infer::infer_stmt;
 use crochet::parser::token_parser;
 use crochet::lexer::lexer;
 use crochet::types::*;
@@ -18,6 +18,38 @@ fn infer(input: &str) -> String {
     let stmt = prog.body.get(0).unwrap();
     let result = infer_stmt(env, &stmt);
     format!("{}", result)
+}
+
+fn infer_prog(src: &str) -> (Program, Env) {
+    let env: Env = HashMap::new();
+    let result = lexer().parse(src).unwrap();
+    let spans: Vec<_> = result.iter().map(|(_, s)| s.to_owned()).collect();
+    let tokens: Vec<_> = result.iter().map(|(t, _)| t.to_owned()).collect();
+    let prog = token_parser(&spans).parse(tokens).unwrap();
+    let env = crochet::infer::infer_prog(env, &prog);
+    
+    (prog, env)
+}
+
+fn build_d_ts(env: &Env, prog: &Program) -> String {
+    let mut lines: Vec<_> = vec![];
+
+    for (statement, _) in &prog.body {
+        match statement {
+            crochet::syntax::Statement::Decl { pattern: (pat, _), value: (expr, _) } => {
+                let name = match pat {
+                    Pattern::Ident { name } => name,
+                };
+                let scheme = env.get(name).unwrap();
+                let result = extend_scheme(&scheme, Some(&expr));
+                let line = format!("export declare const {name} = {result};");
+                lines.push(line.to_owned());
+            },
+            _ => ()
+        }
+    };
+
+    lines.join("\n")
 }
 
 #[test]
@@ -45,39 +77,78 @@ fn infer_fn_param() {
     assert_eq!(infer("(f, x) => f(x) + x"), "((number) => number, number) => number");
 }
 
-fn build_d_ts(env: &Env, prog: &Program) -> String {
-    let mut lines: Vec<_> = vec![];
+#[test]
+fn infer_fn_param_used_with_multiple_other_params() {
+    assert_eq!(infer("(f, x, y) => f(x) + f(y)"), "<a2>((a2) => number, a2, a2) => number");
+}
 
-    for (statement, _) in &prog.body {
-        match statement {
-            crochet::syntax::Statement::Decl { pattern: (pat, _), value: (expr, _) } => {
-                let name = match pat {
-                    Pattern::Ident { name } => name,
-                };
-                let scheme = env.get(name).unwrap();
-                let result = extend_scheme(&scheme, Some(&expr));
-                let line = format!("export declare const {name} = {result};");
-                lines.push(line.to_owned());
-            },
-            _ => ()
-        }
-    };
+#[test]
+fn infer_i_combinator() {
+    let (_, env) = infer_prog("let I = (x) => x");
+    let result = format!("{}", env.get("I").unwrap());
+    assert_eq!(result, "<a1>(a1) => a1");
+}
 
-    lines.join("\n")
+#[test]
+fn infer_k_combinator_not_curried() {
+    let (_, env) = infer_prog("let K = (x, y) => x");
+    let result = format!("{}", env.get("K").unwrap());
+    assert_eq!(result, "<a1, a2>(a1, a2) => a1");
+}
+
+#[test]
+fn infer_s_combinator_not_curried() {
+    let (_, env) = infer_prog("let S = (f, g, x) => f(x, g(x))");
+    let result = format!("{}", env.get("S").unwrap());
+    assert_eq!(result, "<a3, a4, a5>((a3, a4) => a5, (a3) => a4, a3) => a5");
+}
+
+#[test]
+fn infer_k_combinator_curried() {
+    let (_, env) = infer_prog("let K = (x) => (y) => x");
+    let result = format!("{}", env.get("K").unwrap());
+    assert_eq!(result, "<a1, a2>(a1) => (a2) => a1");
+}
+
+#[test]
+fn infer_s_combinator_curried() {
+    let (_, env) = infer_prog("let S = (f) => (g) => (x) => f(x)(g(x))");
+    let result = format!("{}", env.get("S").unwrap());
+    // "<a, b, c>((a) => (b) => c) => ((a) => b) => (a) => c"
+    assert_eq!(result, "<a3, a5, a6>((a3) => (a5) => a6) => ((a3) => a5) => (a3) => a6");
+}
+
+#[test]
+fn infer_skk() {
+    let src = r#"
+    let S = (f) => (g) => (x) => f(x)(g(x))
+    let K = (x) => (y) => x
+    let I = S(K)(K)
+    "#;
+    let (_, env) = infer_prog(src);
+    let result = format!("{}", env.get("I").unwrap());
+    assert_eq!(result, "<a1>(a1) => a1");
+}
+
+#[test]
+fn infer_adding_variables() {
+    let src = r#"
+    let x = 5
+    let y = 10
+    let z = x + y
+    "#;
+    let (_, env) = infer_prog(src);
+    let result = format!("{}", env.get("z").unwrap());
+    assert_eq!(result, "number");
 }
 
 #[test]
 fn infer_decl() {
-    let env: Env = HashMap::new();
     let src = r#"
     let foo = (a, b) => a + b
     let bar = "hello"
     "#;
-    let result = lexer().parse(src).unwrap();
-    let spans: Vec<_> = result.iter().map(|(_, s)| s.to_owned()).collect();
-    let tokens: Vec<_> = result.iter().map(|(t, _)| t.to_owned()).collect();
-    let prog = token_parser(&spans).parse(tokens).unwrap();
-    let env = infer_prog(env, &prog);
+    let (prog, env) = infer_prog(src);
     let result = build_d_ts(&env, &prog);
 
     insta::assert_snapshot!(result, @r###"

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,7 +1,7 @@
 use chumsky::prelude::*;
 use std::collections::HashMap;
 
-use crochet::context::Env;
+use crochet::context::{Context, Env};
 use crochet::infer::infer_stmt;
 use crochet::parser::token_parser;
 use crochet::lexer::lexer;
@@ -11,12 +11,13 @@ use crochet::syntax::{Pattern, Program};
 
 fn infer(input: &str) -> String {
     let env: Env = HashMap::new();
+    let ctx = Context::from(env);
     let result = lexer().parse(input).unwrap();
     let spans: Vec<_> = result.iter().map(|(_, s)| s.to_owned()).collect();
     let tokens: Vec<_> = result.iter().map(|(t, _)| t.to_owned()).collect();
     let prog = token_parser(&spans).parse(tokens).unwrap();
     let stmt = prog.body.get(0).unwrap();
-    let result = infer_stmt(env, &stmt);
+    let result = infer_stmt(&ctx, &stmt);
     format!("{}", result)
 }
 
@@ -127,7 +128,7 @@ fn infer_skk() {
     "#;
     let (_, env) = infer_prog(src);
     let result = format!("{}", env.get("I").unwrap());
-    assert_eq!(result, "<a1>(a1) => a1");
+    assert_eq!(result, "<a5>(a5) => a5");
 }
 
 #[test]


### PR DESCRIPTION
This PR fixes a couple of issues:
- improper application of remaining substitutions in `solver`
- inability of parser to parse more than one application in a row
- make output deterministic
 
The underlying issue for the third bullet point was that `.ftv()` returns a `HashedSet` which doesn't guarantee the iteration order.  This was remedied by sorting the qualifiers in `generalize()`.