### PR TITLE
Remove 'name' property from TVar

### DIFF
--- a/src/constraint_solver.rs
+++ b/src/constraint_solver.rs
@@ -135,7 +135,7 @@ fn bind(tv: &TVar, ty: &Type, _: &Context) -> Subst {
 
     match ty {
         Type::Var(TVar { id, .. }) if id == &tv.id => Subst::new(),
-        ty if ty.ftv().contains(tv) => panic!("type var appears in type"),
+        ty if ty.ftv().contains(&tv.id) => panic!("type var appears in type"),
         ty => {
             let mut subst = Subst::new();
             subst.insert(tv.id, ty.clone());

--- a/src/context.rs
+++ b/src/context.rs
@@ -36,7 +36,7 @@ impl Context {
     fn instantiate(&self, scheme: &Scheme) -> Type {
         let fresh_quals = scheme.qualifiers.iter().map(|_| Type::from(self.fresh()));
 
-        let ids = scheme.qualifiers.iter().map(|qual| qual.id);
+        let ids = scheme.qualifiers.iter().map(|id| id.to_owned());
         // The iterator returned by into_iter may yield any of T, &T or &mut T,
         // depending on the context.
         let subs: Subst = ids.zip(fresh_quals).collect();
@@ -47,9 +47,6 @@ impl Context {
         let id = self.state.count.get() + 1;
         self.state.count.set(id);
 
-        types::TVar {
-            id,
-            name: String::from("a"),
-        }
+        types::TVar { id }
     }
 }

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -14,7 +14,7 @@ impl Substitutable for Constraint {
             types: (self.types.0.apply(sub), self.types.1.apply(sub)),
         }
     }
-    fn ftv(&self) -> HashSet<TVar> {
+    fn ftv(&self) -> HashSet<i32> {
         let mut result = HashSet::new();
         result.extend(self.types.0.ftv());
         result.extend(self.types.1.ftv());
@@ -35,9 +35,9 @@ impl Substitutable for Type {
             Type::Lit(_) => self.clone(),
         }
     }
-    fn ftv(&self) -> HashSet<TVar> {
+    fn ftv(&self) -> HashSet<i32> {
         match self {
-            Type::Var(tv) => HashSet::from([tv.clone()]),
+            Type::Var(tv) => HashSet::from([tv.id]),
             Type::Lam(TLam { args, ret }) => {
                 let mut result: HashSet<_> = args.iter().flat_map(|a| a.ftv()).collect();
                 result.extend(ret.ftv());
@@ -56,8 +56,8 @@ impl Substitutable for Scheme {
             ty: self.ty.apply(sub),
         }
     }
-    fn ftv(&self) -> HashSet<TVar> {
-        let qualifiers: HashSet<_> = self.qualifiers.iter().cloned().collect();
+    fn ftv(&self) -> HashSet<i32> {
+        let qualifiers: HashSet<_> = self.qualifiers.iter().map(|id| id.to_owned()).collect();
         self.ty.ftv().difference(&qualifiers).cloned().collect()
     }
 }
@@ -68,7 +68,7 @@ impl Substitutable for Env {
             .map(|(a, b)| (a.clone(), b.apply(sub)))
             .collect()
     }
-    fn ftv(&self) -> HashSet<TVar> {
+    fn ftv(&self) -> HashSet<i32> {
         // we can't use iter_values() here because it's a consuming iterator
         self.iter().flat_map(|(_, b)| b.ftv()).collect()
     }
@@ -81,7 +81,7 @@ where
     fn apply(&self, sub: &Subst) -> Vec<I> {
         self.iter().map(|c| c.apply(sub)).collect()
     }
-    fn ftv(&self) -> HashSet<TVar> {
+    fn ftv(&self) -> HashSet<i32> {
         self.iter().flat_map(|c| c.ftv()).collect()
     }
 }

--- a/src/substitutable.rs
+++ b/src/substitutable.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 
-use super::types::{TVar, Type};
+use super::types::{Type};
 
 pub type Subst = HashMap<i32, Type>;
 
 pub trait Substitutable {
     fn apply(&self, subs: &Subst) -> Self;
     // TODO: use an ordered set
-    fn ftv(&self) -> HashSet<TVar>;
+    fn ftv(&self) -> HashSet<i32>;
 }

--- a/src/ts/ast.rs
+++ b/src/ts/ast.rs
@@ -6,7 +6,7 @@ use super::super::types::{Primitive, TVar};
 
 pub struct TsQualifiedType {
     pub ty: TsType,
-    pub type_params: Vec<TVar>,
+    pub type_params: Vec<i32>,
 }
 
 #[derive(Debug)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -40,13 +40,12 @@ impl fmt::Display for Primitive {
 #[derive(Clone, Debug, PartialOrd, Ord)]
 pub struct TVar {
     pub id: i32,
-    pub name: String,
 }
 
 impl fmt::Display for TVar {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let Self { name, id } = self;
-        write!(f, "{}{}", name, id)
+        let Self { id, .. } = self;
+        write!(f, "T{}", id)
     }
 }
 
@@ -134,7 +133,7 @@ impl From<&Literal> for Type {
 
 #[derive(Clone, Debug)]
 pub struct Scheme {
-    pub qualifiers: Vec<TVar>,
+    pub qualifiers: Vec<i32>,
     pub ty: Type,
 }
 
@@ -147,7 +146,7 @@ impl fmt::Display for Scheme {
         } else {
             let mut quals = qualifiers.clone();
             quals.sort();
-            write!(f, "<{}>{}", join(quals, ", "), ty)
+            write!(f, "<{}>{}", join(quals.iter().map(|id| format!("T{id}")), ", "), ty)
         }
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -60,7 +60,7 @@ fn infer_number_literal() {
 
 #[test]
 fn infer_lam() {
-    assert_eq!(infer("(x) => x"), "<a1>(a1) => a1");
+    assert_eq!(infer("(x) => x"), "<T1>(T1) => T1");
 }
 
 #[test]
@@ -80,35 +80,35 @@ fn infer_fn_param() {
 
 #[test]
 fn infer_fn_param_used_with_multiple_other_params() {
-    assert_eq!(infer("(f, x, y) => f(x) + f(y)"), "<a2>((a2) => number, a2, a2) => number");
+    assert_eq!(infer("(f, x, y) => f(x) + f(y)"), "<T2>((T2) => number, T2, T2) => number");
 }
 
 #[test]
 fn infer_i_combinator() {
     let (_, env) = infer_prog("let I = (x) => x");
     let result = format!("{}", env.get("I").unwrap());
-    assert_eq!(result, "<a1>(a1) => a1");
+    assert_eq!(result, "<T1>(T1) => T1");
 }
 
 #[test]
 fn infer_k_combinator_not_curried() {
     let (_, env) = infer_prog("let K = (x, y) => x");
     let result = format!("{}", env.get("K").unwrap());
-    assert_eq!(result, "<a1, a2>(a1, a2) => a1");
+    assert_eq!(result, "<T1, T2>(T1, T2) => T1");
 }
 
 #[test]
 fn infer_s_combinator_not_curried() {
     let (_, env) = infer_prog("let S = (f, g, x) => f(x, g(x))");
     let result = format!("{}", env.get("S").unwrap());
-    assert_eq!(result, "<a3, a4, a5>((a3, a4) => a5, (a3) => a4, a3) => a5");
+    assert_eq!(result, "<T3, T4, T5>((T3, T4) => T5, (T3) => T4, T3) => T5");
 }
 
 #[test]
 fn infer_k_combinator_curried() {
     let (_, env) = infer_prog("let K = (x) => (y) => x");
     let result = format!("{}", env.get("K").unwrap());
-    assert_eq!(result, "<a1, a2>(a1) => (a2) => a1");
+    assert_eq!(result, "<T1, T2>(T1) => (T2) => T1");
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn infer_s_combinator_curried() {
     let (_, env) = infer_prog("let S = (f) => (g) => (x) => f(x)(g(x))");
     let result = format!("{}", env.get("S").unwrap());
     // "<a, b, c>((a) => (b) => c) => ((a) => b) => (a) => c"
-    assert_eq!(result, "<a3, a5, a6>((a3) => (a5) => a6) => ((a3) => a5) => (a3) => a6");
+    assert_eq!(result, "<T3, T5, T6>((T3) => (T5) => T6) => ((T3) => T5) => (T3) => T6");
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn infer_skk() {
     "#;
     let (_, env) = infer_prog(src);
     let result = format!("{}", env.get("I").unwrap());
-    assert_eq!(result, "<a5>(a5) => a5");
+    assert_eq!(result, "<T5>(T5) => T5");
 }
 
 #[test]


### PR DESCRIPTION
We'll likely want to re-add 'name' as an optional property in the future to model situations where developers have explicitly provided names for type parameters.  Since `crochet` currently doesn't support specifying types, it doesn't make sense to keep it around right now.