### PR TITLE
Codegen if-else

### DIFF
--- a/demo/app.tsx
+++ b/demo/app.tsx
@@ -23,6 +23,13 @@ export const App = () => {
       "let add = (a, b) => a + b",
       "let sub = (a, b) => a - b",
       "let foo = (f, x) => f(x) + x",
+      "",
+      "let baz = if (true) {",
+      "  let z = 5 in",
+      "  z",
+      "} else {",
+      "  5",
+      "}",
     ].join("\n");
   });
 

--- a/src/js/ast.rs
+++ b/src/js/ast.rs
@@ -42,6 +42,11 @@ pub enum Expression {
         op: UnaryOp,
         arg: Box<Expression>,
     },
+    IfElse {
+        cond: Box<Expression>,
+        consequent: Vec<Statement>,
+        alternate: Vec<Statement>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/js/builder.rs
+++ b/src/js/builder.rs
@@ -120,8 +120,14 @@ pub fn build_expr(expr: &syntax::Expr) -> Expression {
             consequent,
             alternate,
         } => {
-            // Let's go with an IIFE
             // Return an IIFE.
+            // (() => {
+            //    if (cond) {
+            //        return consequent;
+            //    } else {
+            //        return alternate;
+            //    }
+            // })();
             Expression::Call {
                 func: Box::from(Expression::Function {
                     params: vec![],
@@ -135,15 +141,6 @@ pub fn build_expr(expr: &syntax::Expr) -> Expression {
                 }),
                 args: vec![],
             }
-            // TODO: convert an if-else expression in crochet to something
-            // that can be represented in JavaScript.  We can use nested ternaries
-            // and sequences together to implement this.  Sequences help, because
-            // in JavaScript, the last item in the sequence is the value of the
-            // expression.  Sequences aren't quite enough in the situation where
-            // the consequent or alternate are use `let`.  In those situations we
-            // end up having to introduce a variable before the `if-else` and then
-            // set that variable's value at the end of the consequent and alternate.
-            // todo!()
         }
     }
 }

--- a/src/js/builder.rs
+++ b/src/js/builder.rs
@@ -29,6 +29,18 @@ pub fn build_pattern(pattern: &syntax::Pattern) -> Pattern {
     }
 }
 
+pub fn build_return_block(body: &syntax::Expr) -> Vec<Statement> {
+    match body {
+        // Avoids wrapping in an IIFE when it isn't necessary.
+        syntax::Expr::Let { .. } => {
+            let_to_children(body)
+        }
+        _ => vec![Statement::Return {
+            arg: build_expr(body),
+        }]
+    }
+}
+
 pub fn build_expr(expr: &syntax::Expr) -> Expression {
     match expr {
         syntax::Expr::App { lam, args } => {
@@ -66,8 +78,8 @@ pub fn build_expr(expr: &syntax::Expr) -> Expression {
                     params,
                     // The last statement in the body of a function
                     // should always be a `return` statement.
-                    body: vec![Statement::Expression {
-                        expr: build_expr(body),
+                    body: vec![Statement::Return {
+                        arg: build_expr(body),
                     }],
                 },
             }
@@ -100,26 +112,39 @@ pub fn build_expr(expr: &syntax::Expr) -> Expression {
             Expression::Binary { op, left, right }
         }
         syntax::Expr::Fix { expr } => match expr.as_ref() {
-            (syntax::Expr::Lam { body, .. }, _) => {
-                build_expr(&body.0)
-            },
+            (syntax::Expr::Lam { body, .. }, _) => build_expr(&body.0),
             _ => panic!("Fix should only wrap a lambda"),
         },
         syntax::Expr::If {
-            cond: _cond,
-            consequent: _cons,
-            alternate: _alt,
+            cond,
+            consequent,
+            alternate,
         } => {
+            // Let's go with an IIFE
+            // Return an IIFE.
+            Expression::Call {
+                func: Box::from(Expression::Function {
+                    params: vec![],
+                    body: vec![Statement::Expression {
+                        expr: Expression::IfElse {
+                            cond: Box::from(build_expr(&cond.as_ref().0)),
+                            consequent: build_return_block(&consequent.as_ref().0),
+                            alternate: build_return_block(&alternate.as_ref().0),
+                        },
+                    }],
+                }),
+                args: vec![],
+            }
             // TODO: convert an if-else expression in crochet to something
             // that can be represented in JavaScript.  We can use nested ternaries
             // and sequences together to implement this.  Sequences help, because
-            // in JavaScript, the last item in the sequence is the value of the 
+            // in JavaScript, the last item in the sequence is the value of the
             // expression.  Sequences aren't quite enough in the situation where
             // the consequent or alternate are use `let`.  In those situations we
             // end up having to introduce a variable before the `if-else` and then
             // set that variable's value at the end of the consequent and alternate.
-            todo!()
-        },
+            // todo!()
+        }
     }
 }
 

--- a/src/js/printer.rs
+++ b/src/js/printer.rs
@@ -91,6 +91,7 @@ pub fn print_expr(expr: &Expression, level: &u32) -> String {
         }
         Expression::Function { params, body } => {
             let params = params.iter().map(|param| print_param(param)).join(", ");
+            // TODO: Support arrow function shorthand
             // let wrap = body.len() <= 1;
             let wrap = false;
             let new_level = if wrap { *level } else { *level + 1 };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -158,7 +158,12 @@ pub fn token_parser(
 
         let lam = param_list
             .then_ignore(just(Token::FatArrow))
-            .then(expr.clone())
+            .then(
+                choice((
+                    expr.clone().delimited_by(just(Token::OpenBrace), just(Token::CloseBrace)),
+                    expr.clone(),
+                )),
+            )
             .map_with_span(|(args, body), token_span: Span| {
                 let start = source_spans.get(token_span.start).unwrap().start;
                 let end = source_spans.get(token_span.end - 1).unwrap().end;

--- a/tests/codegen_test.rs
+++ b/tests/codegen_test.rs
@@ -47,17 +47,29 @@ fn call_with_no_args() {
 
 #[test]
 fn lambda_with_two_args() {
-    insta::assert_snapshot!(compile("(a, b) => a + b"), @"(a, b) => a + b;");
+    insta::assert_snapshot!(compile("(a, b) => a + b"), @r###"
+    (a, b) => {
+        return a + b;
+    };
+    "###);
 }
 
 #[test]
 fn lambda_with_one_arg() {
-    insta::assert_snapshot!(compile("(a) => a"), @"(a) => a;");
+    insta::assert_snapshot!(compile("(a) => a"), @r###"
+    (a) => {
+        return a;
+    };
+    "###);
 }
 
 #[test]
 fn lambda_with_no_args() {
-    insta::assert_snapshot!(compile("() => 5"), @"() => 5;");
+    insta::assert_snapshot!(compile("() => 5"), @r###"
+    () => {
+        return 5;
+    };
+    "###);
 }
 
 #[test]
@@ -98,7 +110,9 @@ fn subtraction_with_parens() {
 #[test]
 fn function_declaration() {
     insta::assert_snapshot!(compile("let add = (a, b) => a + b"), @r###"
-    const add = (a, b) => a + b;
+    const add = (a, b) => {
+        return a + b;
+    };
 
     export {add};
     "###);
@@ -143,7 +157,9 @@ fn nested_let_in_inside_declaration() {
 #[test]
 fn js_print_simple_lambda() {
     insta::assert_snapshot!(compile("let add = (a, b) => a + b"), @r###"
-    const add = (a, b) => a + b;
+    const add = (a, b) => {
+        return a + b;
+    };
 
     export {add};
     "###);
@@ -192,7 +208,11 @@ fn js_print_let_in_inside_lambda() {
 #[test]
 fn js_print_nested_lambdas() {
     insta::assert_snapshot!(compile("let foo = (a) => (b) => a + b"), @r###"
-    const foo = (a) => (b) => a + b;
+    const foo = (a) => {
+        return (b) => {
+            return a + b;
+        };
+    };
 
     export {foo};
     "###);
@@ -201,9 +221,11 @@ fn js_print_nested_lambdas() {
 #[test]
 fn js_print_nested_lambdas_with_multiple_lines() {
     insta::assert_snapshot!(compile("let foo = (a) => (b) => let sum = a + b in sum"), @r###"
-    const foo = (a) => (b) => {
-        const sum = a + b;
-        return sum;
+    const foo = (a) => {
+        return (b) => {
+            const sum = a + b;
+            return sum;
+        };
     };
 
     export {foo};

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -238,9 +238,19 @@ fn codegen_if_else() {
     "#;
     let (prog, env) = infer_prog(src);
 
-    // TODO: enable this assertion once we can codegen if-else
-    // let js_tree = build_js(&prog);
-    // insta::assert_snapshot!(print_js(&js_tree), @"");
+    let js_tree = build_js(&prog);
+    insta::assert_snapshot!(print_js(&js_tree), @r###"
+    const cond = true;
+    const result = (() => {
+        if (cond) {
+            return 5;
+        } else {
+            return 5;
+        };
+    })();
+
+    export {cond, result};
+    "###);
 
     insta::assert_snapshot!(build_d_ts(&env, &prog), @r###"
     export declare const cond = true;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -222,7 +222,9 @@ fn codegen_let_rec() {
     let js_tree = build_js(&prog);
 
     insta::assert_snapshot!(print_js(&js_tree), @r###"
-    const f = () => f();
+    const f = () => {
+        return f();
+    };
 
     export {f};
     "###);


### PR DESCRIPTION
This PR also removes arrow function shorthand that was being used in some situations in order to make the js builder/printer simpler for now.  At some point in the future, shorthand will be re-enabled.