### PR TITLE
Add support for async/await

### DIFF
--- a/demo/app.tsx
+++ b/demo/app.tsx
@@ -32,6 +32,8 @@ export const App = () => {
       "}",
       "",
       "let point = {x: 5, y: 10}",
+      "",
+      "let add = async (a, b) => await a() + await b()",
     ].join("\n");
   });
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -16,6 +16,7 @@ pub struct State {
 pub struct Context {
     pub env: Env,
     pub state: State,
+    pub r#async: bool,
 }
 
 impl From<Env> for Context {
@@ -25,6 +26,7 @@ impl From<Env> for Context {
             state: State {
                 count: Cell::new(0),
             },
+            r#async: false,
         }
     }
 }
@@ -98,6 +100,16 @@ impl Context {
         types::TProp {
             name: name.to_owned(),
             ty,
+        }
+    }
+    pub fn alias(&self, name: &str, type_params: Vec<Type>) -> Type {
+        types::Type {
+            id: self.fresh_id(),
+            frozen: false,
+            kind: TypeKind::Alias {
+                name: name.to_owned(),
+                type_params: type_params.to_owned(),
+            },
         }
     }
 }

--- a/src/js/ast.rs
+++ b/src/js/ast.rs
@@ -28,6 +28,7 @@ pub enum Expression {
     Function {
         params: Vec<Param>,
         body: Vec<Statement>,
+        r#async: bool,
     },
     Ident {
         name: String,
@@ -50,6 +51,9 @@ pub enum Expression {
     Object {
         properties: Vec<Property>,
     },
+    Await {
+        expr: Box<Expression>,
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -6,6 +6,8 @@ pub enum Token {
     Ident(String),
 
     // keywords
+    Async,
+    Await,
     Else,
     If,
     In,
@@ -46,6 +48,8 @@ impl fmt::Display for Token {
             Token::Plus => write!(f, "+"),
             Token::Times => write!(f, "*"),
             Token::Div => write!(f, "/"),
+            Token::Async => write!(f, "async"),
+            Token::Await => write!(f, "await"),
             Token::Else => write!(f, "else"),
             Token::If => write!(f, "if"),
             Token::Let => write!(f, "let"),
@@ -105,6 +109,8 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = Simple<char>> {
     let ident = text::ident::<char, Simple<char>>();
 
     let word = ident.map(|s: String| match s.as_str() {
+        "async" => Token::Async,
+        "await" => Token::Await,
         "let" => Token::Let,
         "in" => Token::In,
         "if" => Token::If,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -248,8 +248,7 @@ pub fn token_parser(
                 }
             });
 
-        // NOTE: `let` is an expressionb because it current models
-        // let-in.
+        // NOTE: `let` is an expression because it currently models let-in.
         choice((lam, r#let, sum))
     });
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -56,6 +56,9 @@ pub enum Expr {
     Obj {
         properties: Vec<WithSpan<Property>>,
     },
+    Await {
+        expr: Box<WithSpan<Expr>>,
+    },
 }
 
 // TODO: rename this to something else since we can't use it for let bindings

--- a/src/ts/ast.rs
+++ b/src/ts/ast.rs
@@ -20,6 +20,10 @@ pub enum TsType {
     },
     Union(Vec<TsType>),
     Obj(Vec<TsObjProp>),
+    Alias {
+        name: String,
+        type_params: Vec<TsType>,
+    },
 }
 
 impl fmt::Display for TsQualifiedType {
@@ -68,6 +72,10 @@ impl fmt::Display for TsType {
 
                 // TODO: output multi-line object types
                 write!(f, "{{{props}}}")
+            }
+            TsType::Alias {name, type_params} => {
+                let type_params = type_params.iter().join(", ");
+                write!(f, "{name}<{type_params}>")
             }
         }
     }

--- a/src/ts/convert.rs
+++ b/src/ts/convert.rs
@@ -93,5 +93,15 @@ pub fn convert_type(ty: &Type, expr: Option<&Expr>) -> TsType {
                 .collect();
             TsType::Obj(props)
         }
+        TypeKind::Alias { name, type_params } => {
+            let type_params: Vec<_> = type_params
+                .iter()
+                .map(|ty| convert_type(ty, None))
+                .collect();
+            TsType::Alias {
+                name: name.to_owned(),
+                type_params,
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR also introduces `TypeKind::Alias`, _et al_ to model `Promise<T>` types.