### PR TITLE
Reorganize literal AST nodes

### DIFF
--- a/src/constraint_solver.rs
+++ b/src/constraint_solver.rs
@@ -1,5 +1,4 @@
 use super::context::Context;
-use super::literal::Literal;
 use super::substitutable::*;
 use super::types::*;
 
@@ -152,9 +151,9 @@ fn unify_many(cs: &[Constraint], ctx: &Context) -> Subst {
 
 fn is_subtype(t1: &Type, t2: &Type) -> bool {
     match (&t1.kind, &t2.kind) {
-        (TypeKind::Lit(Literal::Num(_)), TypeKind::Prim(Primitive::Num)) => true,
-        (TypeKind::Lit(Literal::Str(_)), TypeKind::Prim(Primitive::Str)) => true,
-        (TypeKind::Lit(Literal::Bool(_)), TypeKind::Prim(Primitive::Bool)) => true,
+        (TypeKind::Lit(Lit::Num(_)), TypeKind::Prim(Primitive::Num)) => true,
+        (TypeKind::Lit(Lit::Str(_)), TypeKind::Prim(Primitive::Str)) => true,
+        (TypeKind::Lit(Lit::Bool(_)), TypeKind::Prim(Primitive::Bool)) => true,
         _ => false,
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,6 @@
-use super::literal::Literal;
 use super::substitutable::*;
 use super::types::{self, Scheme, Type, TypeKind};
+use super::literal::Lit;
 
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -75,11 +75,17 @@ impl Context {
             kind: types::TypeKind::Prim(prim),
         }
     }
-    pub fn from_lit(&self, lit: Literal) -> Type {
+    pub fn from_lit(&self, lit: Lit) -> Type {
         types::Type {
             id: self.fresh_id(),
             frozen: false,
-            kind: types::TypeKind::Lit(lit),
+            kind: match lit {
+                Lit::Num(n) => types::TypeKind::Lit(types::Lit::Num(n.value)),
+                Lit::Bool(b) => types::TypeKind::Lit(types::Lit::Bool(b.value)),
+                Lit::Str(s) => types::TypeKind::Lit(types::Lit::Str(s.value)),
+                Lit::Null(_) => types::TypeKind::Lit(types::Lit::Null),
+                Lit::Undefined(_) => types::TypeKind::Lit(types::Lit::Undefined),
+            }
         }
     }
     pub fn union(&self, types: &[Type]) -> Type {

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -405,7 +405,7 @@ fn infer(expr: &Expr, ctx: &Context) -> InferResult {
 
             (t2.apply(&subs), vec![])
         }
-        Expr::Lit(Lit { literal, .. }) => (ctx.from_lit(literal.to_owned()), vec![]),
+        Expr::Lit(literal) => (ctx.from_lit(literal.to_owned()), vec![]),
         // TODO: check the `op` field when we introduce comparison operators
         Expr::Op(Op { left, right, .. }) => {
             let left = Box::as_ref(left);

--- a/src/js/ast.rs
+++ b/src/js/ast.rs
@@ -1,4 +1,4 @@
-use super::super::literal::Literal;
+use super::super::literal::Lit;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Program {
@@ -33,7 +33,7 @@ pub enum Expression {
     Ident {
         name: String,
     },
-    Literal {literal: Literal},
+    Literal(Lit),
     Binary {
         op: BinaryOp,
         left: Box<Expression>,

--- a/src/js/builder.rs
+++ b/src/js/builder.rs
@@ -102,9 +102,7 @@ pub fn build_expr(expr: &syntax::Expr) -> Expression {
                 args: vec![],
             }
         }
-        syntax::Expr::Lit(syntax::Lit { literal, .. }) => Expression::Literal {
-            literal: literal.to_owned(),
-        },
+        syntax::Expr::Lit(lit) => Expression::Literal(lit.to_owned()),
         syntax::Expr::Op(syntax::Op {
             op, left, right, ..
         }) => {

--- a/src/js/printer.rs
+++ b/src/js/printer.rs
@@ -118,7 +118,7 @@ pub fn print_expr(expr: &Expression, level: &u32) -> String {
             }
         }
         Expression::Ident { name } => name.to_owned(),
-        Expression::Literal { literal } => format!("{literal}"),
+        Expression::Literal(lit) => format!("{lit}"),
         Expression::Binary { op, left, right } => {
             let wrap_right = match (expr, right.as_ref()) {
                 (

--- a/src/literal.rs
+++ b/src/literal.rs
@@ -1,48 +1,78 @@
 use std::fmt;
 
+pub type Span = std::ops::Range<usize>;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Literal {
+pub struct Num {
+    pub span: Span,
+    pub value: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Bool {
+    pub span: Span,
+    pub value: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Str {
+    pub span: Span,
+    pub value: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Null {
+    pub span: Span,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Undefined {
+    pub span: Span,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Lit {
     // We store all of the values as strings since f64 doesn't
     // support the Eq trait because NaN and 0.1 + 0.2 != 0.3.
-    Num(String),
-    Bool(String),
-    Str(String),
-    Null,
-    Undefined,
+    Num(Num),
+    Bool(Bool),
+    Str(Str),
+    Null(Null),
+    Undefined(Undefined),
 }
 
-impl From<&str> for Literal {
-    fn from(s: &str) -> Self {
-        Literal::Str(s.to_owned())
+impl Lit {
+    pub fn bool(value: bool, span: Span) -> Self {
+        Lit::Bool(Bool { value, span })
+    }
+
+    pub fn str(value: String, span: Span) -> Self {
+        Lit::Str(Str { value, span })
+    }
+
+    pub fn num(value: String, span: Span) -> Self {
+        Lit::Num(Num { value, span })
+    }
+
+    pub fn span(&self) -> Span {
+        match &self {
+            Lit::Num(n) => n.span.to_owned(),
+            Lit::Bool(b) => b.span.to_owned(),
+            Lit::Str(s) => s.span.to_owned(),
+            Lit::Null(n) => n.span.to_owned(),
+            Lit::Undefined(u) => u.span.to_owned(),
+        }
     }
 }
 
-impl From<String> for Literal {
-    fn from(s: String) -> Self {
-        Literal::Str(s)
-    }
-}
-
-impl From<&bool> for Literal {
-    fn from(b: &bool) -> Self {
-        Literal::Bool(b.to_string())
-    }
-}
-
-impl From<bool> for Literal {
-    fn from(b: bool) -> Self {
-        Literal::Bool(b.to_string())
-    }
-}
-
-impl fmt::Display for Literal {
+impl fmt::Display for Lit {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Literal::Num(val) => write!(f, "{}", val),
-            Literal::Bool(val) => write!(f, "{}", val),
-            Literal::Str(val) => write!(f, "\"{}\"", val),
-            Literal::Null => write!(f, "null"),
-            Literal::Undefined => write!(f, "undefined"),
+            Lit::Num(n) => write!(f, "{}", n.value),
+            Lit::Bool(b) => write!(f, "{}", b.value),
+            Lit::Str(s) => write!(f, "\"{}\"", s.value),
+            Lit::Null(_) => write!(f, "null"),
+            Lit::Undefined(_) => write!(f, "undefined"),
         }
     }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,4 +1,4 @@
-use super::literal::Literal;
+use super::literal::Lit;
 
 pub type Span = std::ops::Range<usize>;
 
@@ -92,12 +92,6 @@ pub struct Let {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Lit {
-    pub span: Span,
-    pub literal: Literal,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Op {
     pub span: Span,
     pub op: BinOp,
@@ -142,7 +136,7 @@ impl Expr {
             Expr::JSXElement(_) => todo!(),
             Expr::Lambda(Lambda{ span, .. }) => span.to_owned(),
             Expr::Let(Let { span, .. }) => span.to_owned(),
-            Expr::Lit(Lit { span, .. }) => span.to_owned(),
+            Expr::Lit(lit) => lit.span(),
             Expr::Op(Op { span, .. }) => span.to_owned(),
             Expr::Obj(Obj { span, .. }) => span.to_owned(),
             Expr::Await(Await { span, .. }) => span.to_owned(),

--- a/src/ts/convert.rs
+++ b/src/ts/convert.rs
@@ -1,6 +1,6 @@
 use super::super::syntax::{BindingIdent, Expr, Fix, Lambda};
 use super::super::types::{Scheme, TLam, Type, TypeKind};
-use super::ast::{Param, TsObjProp, TsQualifiedType, TsType};
+use super::ast::{Param, TsObjProp, TsQualifiedType, TsType, Func, Alias};
 
 /// Converts a Scheme to a TsQualifiedTyepe for eventual export to .d.ts.
 pub fn convert_scheme(scheme: &Scheme, expr: Option<&Expr>) -> TsQualifiedType {
@@ -51,10 +51,10 @@ pub fn convert_type(ty: &Type, expr: Option<&Expr>) -> TsType {
                             })
                             .collect();
 
-                        TsType::Func {
+                        TsType::Func(Func {
                             params,
                             ret: Box::new(convert_type(&ret, None)),
-                        }
+                        })
                     }
                 }
                 // Fix nodes are assumed to wrap a lambda where the body of
@@ -72,10 +72,10 @@ pub fn convert_type(ty: &Type, expr: Option<&Expr>) -> TsType {
                             ty: convert_type(arg, None),
                         })
                         .collect();
-                    TsType::Func {
+                    TsType::Func(Func {
                         params,
                         ret: Box::new(convert_type(&ret, None)),
-                    }
+                    })
                 }
                 _ => panic!("mismatch"),
             }
@@ -98,10 +98,10 @@ pub fn convert_type(ty: &Type, expr: Option<&Expr>) -> TsType {
                 .iter()
                 .map(|ty| convert_type(ty, None))
                 .collect();
-            TsType::Alias {
+            TsType::Alias(Alias {
                 name: name.to_owned(),
                 type_params,
-            }
+            })
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,28 @@
 use itertools::join;
 use std::fmt;
 
-use super::literal::Literal;
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Lit {
+    // We store all of the values as strings since f64 doesn't
+    // support the Eq trait because NaN and 0.1 + 0.2 != 0.3.
+    Num(String),
+    Bool(bool),
+    Str(String),
+    Null,
+    Undefined,
+}
+
+impl fmt::Display for Lit {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Lit::Num(n) => write!(f, "{}", n),
+            Lit::Bool(b) => write!(f, "{}", b),
+            Lit::Str(s) => write!(f, "\"{}\"", s),
+            Lit::Null => write!(f, "null"),
+            Lit::Undefined => write!(f, "undefined"),
+        }
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Primitive {
@@ -55,7 +76,7 @@ pub enum TypeKind {
     Var,
     Lam(TLam),
     Prim(Primitive),
-    Lit(Literal),
+    Lit(Lit),
     Union(Vec<Type>),
     Obj(Vec<TProp>),
     Alias {
@@ -125,24 +146,5 @@ impl fmt::Display for Scheme {
                 ty
             )
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
-
-    #[test]
-    fn test_fmt_literal() {
-        assert_eq!(
-            format!("{}", Literal::from("hello")),
-            String::from("\"hello\"")
-        );
-        assert_eq!(
-            format!("{}", Literal::Num(String::from("5.0"))),
-            String::from("5.0")
-        );
-        assert_eq!(format!("{}", Literal::from(true)), String::from("true"));
     }
 }


### PR DESCRIPTION
- have separate enums for value literals and type literals
- add structs for value literals
