### PR TITLE
Add support for parsing common JSX expressions

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2,6 +2,7 @@ use crate::ast::ident::Ident;
 use crate::ast::literal::Lit;
 use crate::ast::pattern::Pattern;
 use crate::ast::span::Span;
+use crate::ast::jsx::JSXElement;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Program {
@@ -19,34 +20,6 @@ pub enum Statement {
         span: Span,
         expr: Expr,
     }, // NOTE: does not include Expr::Let
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct JSXText {
-    span: Span,
-    value: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct JSXExprContainer {
-    span: Span,
-    expr: Box<Expr>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct JSXElement {
-    // Other ASTs make have JSXOpeningElement and JSXClosingElement
-    pub name: String,
-    pub children: Vec<JSXElementChild>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum JSXElementChild {
-    JSXText(JSXText),
-    JSXExprContainer(JSXExprContainer),
-    // JSXSpreadChild(JSXSpreadChild),
-    JSXElement(Box<JSXElement>),
-    // JSXFragment(JSXFragment),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/ast/jsx.rs
+++ b/src/ast/jsx.rs
@@ -1,0 +1,47 @@
+use crate::ast::expr::Expr;
+use crate::ast::ident::Ident;
+use crate::ast::literal::Lit;
+use crate::ast::span::Span;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JSXText {
+    pub span: Span,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JSXExprContainer {
+    pub span: Span,
+    pub expr: Expr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JSXElement {
+    pub span: Span,
+    // Other ASTs make have JSXOpeningElement and JSXClosingElement
+    pub name: String,
+    pub attrs: Vec<JSXAttr>,
+    pub children: Vec<JSXElementChild>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JSXElementChild {
+    JSXText(JSXText),
+    JSXExprContainer(JSXExprContainer),
+    // JSXSpreadChild(JSXSpreadChild),
+    JSXElement(Box<JSXElement>),
+    // JSXFragment(JSXFragment),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JSXAttr {
+    pub span: Span,
+    pub ident: Ident,
+    pub value: JSXAttrValue,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JSXAttrValue {
+    Lit(Lit),
+    JSXExprContainer(JSXExprContainer),
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,11 +1,13 @@
 pub mod expr;
 pub mod ident;
+pub mod jsx;
 pub mod literal;
 pub mod pattern;
 pub mod span;
 
 pub use expr::*;
 pub use ident::*;
+pub use jsx::*;
 pub use literal::*;
 pub use pattern::*;
 pub use span::*;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1562,7 +1562,7 @@ mod tests {
         Program {
             body: [
                 Expr {
-                    span: 0..16,
+                    span: 0..11,
                     expr: JSXElement(
                         JSXElement {
                             span: 0..11,


### PR DESCRIPTION
We can now parse the following:
- opening and closing tags
- attributes that are strings or expressions
- text and expressions as children
