### PR TITLE
Infer JSXElement

### DIFF
--- a/demo/app.tsx
+++ b/demo/app.tsx
@@ -34,6 +34,9 @@ export const App = () => {
       "let point = {x: 5, y: 10}",
       "",
       "let add = async (a, b) => await a() + await b()",
+      "",
+      "let msg = \"world\"",
+      "let elem = <div point={point} id=\"point\">Hello, {msg}</div>",
     ].join("\n");
   });
 

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -101,7 +101,7 @@ impl Expr {
             Expr::Fix(fix) => fix.span.to_owned(),
             Expr::Ident(ident) => ident.span.to_owned(),
             Expr::IfElse(if_else) => if_else.span.to_owned(),
-            Expr::JSXElement(_) => todo!(),
+            Expr::JSXElement(elem) => elem.span.to_owned(),
             Expr::Lambda(lam) => lam.span.to_owned(),
             Expr::Let(r#let) => r#let.span.to_owned(),
             Expr::Lit(lit) => lit.span(),

--- a/src/infer/infer.rs
+++ b/src/infer/infer.rs
@@ -332,7 +332,16 @@ fn infer(expr: &Expr, ctx: &Context) -> InferResult {
 
             (tv, cs)
         }
-        Expr::JSXElement(_) => todo!(),
+        Expr::JSXElement(JSXElement { span: _, name: _, attrs: _, children: _ }) => {
+            // TODO: check that the `attrs` match the props of the component/tag with
+            // the given `name`.  If there are any `children`, check that they matches
+            // props['children'].
+
+            // TODO: replace this with JSX.Element once we have support for Type::Mem
+            let ty = ctx.alias("JSXElement", vec![]);
+            
+            (ty, vec![])
+        },
     }
 }
 


### PR DESCRIPTION
This doesn't type check the props yet.  We need to be able to import TypeScript .d.ts files first before we can even think about adding type checking for props.