### PR TITLE
Normalize union types when widening

### DIFF
--- a/demo/app.tsx
+++ b/demo/app.tsx
@@ -37,6 +37,16 @@ export const App = () => {
       "",
       "let msg = \"world\"",
       "let elem = <div point={point} id=\"point\">Hello, {msg}</div>",
+      "",
+      "let rec fib = (n) => if (n == 0) {",
+      "  0",
+      "} else {",
+      "  if (n == 1) {",
+      "      1",
+      "  } else {",
+      "      fib(n - 1) + fib(n - 2)",
+      "  }",
+      "}",
     ].join("\n");
   });
 

--- a/src/infer/constraint_solver.rs
+++ b/src/infer/constraint_solver.rs
@@ -328,4 +328,14 @@ mod tests {
             ctx.prim(Primitive::Str),
         ]));
     }
+
+    #[test]
+    fn union_of_type_vars() {
+        let ctx = Context::new();
+        let t1 = ctx.fresh_var();
+        let t2 = ctx.fresh_var();
+        
+        let result = union_types(&t1, &t2, &ctx);
+        assert_eq!(result, ctx.union(vec![t1, t2]));
+    }
 }

--- a/src/infer/context.rs
+++ b/src/infer/context.rs
@@ -33,6 +33,16 @@ impl From<Env> for Context {
 }
 
 impl Context {
+    pub fn new() -> Self {
+        Context {
+            env: HashMap::new(),
+            state: State {
+                count: Cell::from(0),
+            },
+            is_async: false,
+        }
+    }
+
     pub fn lookup_env(&self, name: &str) -> Type {
         let scheme = self.env.get(name).unwrap();
         self.instantiate(scheme)
@@ -89,11 +99,18 @@ impl Context {
             },
         })
     }
-    pub fn union(&self, types: &[Type]) -> Type {
+    pub fn lit_type(&self, lit: types::Lit) -> Type {
+        Type::Lit(types::LitType {
+            id: self.fresh_id(),
+            frozen: false,
+            lit,
+        })
+    }
+    pub fn union(&self, types: Vec<Type>) -> Type {
         Type::Union(types::UnionType {
             id: self.fresh_id(),
             frozen: false,
-            types: types.to_owned(),
+            types,
         })
     }
     pub fn object(&self, properties: &[types::TProp]) -> Type {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,8 @@
 use itertools::join;
 use std::fmt;
+use std::hash::Hash;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Lit {
     // We store all of the values as strings since f64 doesn't
     // support the Eq trait because NaN and 0.1 + 0.2 != 0.3.
@@ -24,7 +25,7 @@ impl fmt::Display for Lit {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Primitive {
     Num,
     Bool,
@@ -45,7 +46,7 @@ impl fmt::Display for Primitive {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TProp {
     pub name: String,
     pub ty: Type,
@@ -58,13 +59,25 @@ impl fmt::Display for TProp {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq)]
 pub struct VarType {
     pub id: i32,
     pub frozen: bool,
 }
 
-#[derive(Clone, Debug)]
+impl PartialEq for VarType {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Hash for VarType {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+#[derive(Clone, Debug, Eq)]
 pub struct LamType {
     pub id: i32,
     pub frozen: bool,
@@ -72,35 +85,96 @@ pub struct LamType {
     pub ret: Box<Type>,
 }
 
-#[derive(Clone, Debug)]
+impl PartialEq for LamType {
+    fn eq(&self, other: &Self) -> bool {
+        self.args == other.args && self.ret == other.ret
+    }
+}
+
+impl Hash for LamType {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.args.hash(state);
+        self.ret.hash(state);
+    }
+}
+
+#[derive(Clone, Debug, Eq)]
 pub struct PrimType {
     pub id: i32,
     pub frozen: bool,
     pub prim: Primitive,
 }
 
-#[derive(Clone, Debug)]
+impl PartialEq for PrimType {
+    fn eq(&self, other: &Self) -> bool {
+        self.prim == other.prim
+    }
+}
+
+impl Hash for PrimType {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.prim.hash(state);
+    }
+}
+
+#[derive(Clone, Debug, Eq)]
 pub struct LitType {
     pub id: i32,
     pub frozen: bool,
     pub lit: Lit,
 }
 
-#[derive(Clone, Debug)]
+impl PartialEq for LitType {
+    fn eq(&self, other: &Self) -> bool {
+        self.lit == other.lit
+    }
+}
+
+impl Hash for LitType {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.lit.hash(state);
+    }
+}
+
+#[derive(Clone, Debug, Eq)]
 pub struct UnionType {
     pub id: i32,
     pub frozen: bool,
     pub types: Vec<Type>,
 }
 
-#[derive(Clone, Debug)]
+impl PartialEq for UnionType {
+    fn eq(&self, other: &Self) -> bool {
+        self.types == other.types
+    }
+}
+
+impl Hash for UnionType {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.types.hash(state);
+    }
+}
+
+#[derive(Clone, Debug, Eq)]
 pub struct ObjectType {
     pub id: i32,
     pub frozen: bool,
     pub props: Vec<TProp>,
 }
 
-#[derive(Clone, Debug)]
+impl PartialEq for ObjectType {
+    fn eq(&self, other: &Self) -> bool {
+        self.props == other.props
+    }
+}
+
+impl Hash for ObjectType {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.props.hash(state);
+    }
+}
+
+#[derive(Clone, Debug, Eq)]
 pub struct AliasType {
     pub id: i32,
     pub frozen: bool,
@@ -108,7 +182,20 @@ pub struct AliasType {
     pub type_params: Vec<Type>,
 }
 
-#[derive(Clone, Debug)]
+impl PartialEq for AliasType {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.type_params == other.type_params
+    }
+}
+
+impl Hash for AliasType {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        self.type_params.hash(state);
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Type {
     Var(VarType),
     Lam(LamType),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -249,8 +249,8 @@ fn infer_fib() {
     "###;
 
     let (_, env) = infer_prog(src);
-    // TODO: simplify union types before returning them
-    assert_eq!(format!("{}", env.get("fib").unwrap()), "(number | 1 | 0 | number | number) => number | 0 | 1");
+    let fib_type = env.get("fib").unwrap();
+    assert_eq!(format!("{}", fib_type), "(number) => number");
 }
 
 #[test]


### PR DESCRIPTION
When widening types, the union of the two types should has the following characteristics:
- no duplicate types
- types should be sorted (based on their `id`)
- primitive types should subsume their corresponding literal types, e.g. `number | 5` -> `number`
- if there's only a single type in the union, then that type should be return instead of a union type