### PR TITLE
Initial support for parsing explicit type annotations

### DIFF
--- a/src/ast/literal.rs
+++ b/src/ast/literal.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-pub type Span = std::ops::Range<usize>;
+use crate::ast::span::Span;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Num {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -12,4 +12,4 @@ pub use jsx::*;
 pub use literal::*;
 pub use pattern::*;
 pub use span::*;
-pub use types::*;
+pub use types::{TypeAnn, PrimType, LamType, LitType, TypeRef};

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -12,4 +12,4 @@ pub use jsx::*;
 pub use literal::*;
 pub use pattern::*;
 pub use span::*;
-pub use types::{TypeAnn, PrimType, LamType, LitType, TypeRef};
+pub use types::{TypeAnn, PrimType, LamType, LitType, TypeRef, ObjectType, TProp, UnionType};

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -28,12 +28,31 @@ pub struct TypeRef {
     pub type_params: Option<Vec<TypeAnn>>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObjectType {
+    pub span: Span,
+    pub props: Vec<TProp>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TProp {
+    pub span: Span,
+    pub name: String,
+    pub type_ann: Box<TypeAnn>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnionType {
+    pub span: Span,
+    pub types: Vec<TypeAnn>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeAnn {
-    TypeRef(TypeRef),
     Lam(LamType),
-    Prim(PrimType),
     Lit(LitType),
-    // Union(UnionType),
-    // Object(ObjectType),
+    Prim(PrimType),
+    Object(ObjectType),
+    TypeRef(TypeRef),
+    Union(UnionType),
 }

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -1,13 +1,39 @@
-// TODO: add variants to model various types
+use crate::ast::span::Span;
+use crate::ast::literal::Lit;
+use crate::types::{Primitive};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LamType {
+    pub span: Span,
+    pub args: Vec<TypeAnn>,
+    pub ret: Box<TypeAnn>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PrimType {
+    pub span: Span,
+    pub prim: Primitive,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LitType {
+    pub span: Span,
+    pub lit: Lit,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TypeRef {
+    pub span: Span,
+    pub name: String,
+    pub type_params: Option<Vec<TypeAnn>>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeAnn {
-    // copied from src/types.rs
-    // Var(VarType),
-    // Lam(LamType),
-    // Prim(PrimType),
-    // Lit(LitType),
+    TypeRef(TypeRef),
+    Lam(LamType),
+    Prim(PrimType),
+    Lit(LitType),
     // Union(UnionType),
     // Object(ObjectType),
-    // Alias(AliasType),
 }

--- a/src/snapshots/crochet__parser__tests__type_annotations-10.snap
+++ b/src/snapshots/crochet__parser__tests__type_annotations-10.snap
@@ -1,0 +1,46 @@
+---
+source: src/parser.rs
+expression: "parse_type(\"((A, B) => C) | D\")"
+---
+Union(
+    UnionType {
+        span: 0..17,
+        types: [
+            Lam(
+                LamType {
+                    span: 1..12,
+                    args: [
+                        TypeRef(
+                            TypeRef {
+                                span: 2..3,
+                                name: "A",
+                                type_params: None,
+                            },
+                        ),
+                        TypeRef(
+                            TypeRef {
+                                span: 5..6,
+                                name: "B",
+                                type_params: None,
+                            },
+                        ),
+                    ],
+                    ret: TypeRef(
+                        TypeRef {
+                            span: 11..12,
+                            name: "C",
+                            type_params: None,
+                        },
+                    ),
+                },
+            ),
+            TypeRef(
+                TypeRef {
+                    span: 16..17,
+                    name: "D",
+                    type_params: None,
+                },
+            ),
+        ],
+    },
+)

--- a/src/snapshots/crochet__parser__tests__type_annotations-2.snap
+++ b/src/snapshots/crochet__parser__tests__type_annotations-2.snap
@@ -1,0 +1,36 @@
+---
+source: src/parser.rs
+expression: "parse(\"let msg: string = \\\"hello\\\"\")"
+---
+Program {
+    body: [
+        Decl {
+            span: 0..25,
+            pattern: Ident(
+                BindingIdent {
+                    span: 4..16,
+                    id: Ident {
+                        span: 4..16,
+                        name: "msg",
+                    },
+                    type_ann: Some(
+                        Prim(
+                            PrimType {
+                                span: 9..15,
+                                prim: Str,
+                            },
+                        ),
+                    ),
+                },
+            ),
+            value: Lit(
+                Str(
+                    Str {
+                        span: 18..25,
+                        value: "hello",
+                    },
+                ),
+            ),
+        },
+    ],
+}

--- a/src/snapshots/crochet__parser__tests__type_annotations-3.snap
+++ b/src/snapshots/crochet__parser__tests__type_annotations-3.snap
@@ -1,0 +1,81 @@
+---
+source: src/parser.rs
+expression: "parse(\"let add = (a: number, b: number) => a + b\")"
+---
+Program {
+    body: [
+        Decl {
+            span: 0..41,
+            pattern: Ident(
+                BindingIdent {
+                    span: 4..7,
+                    id: Ident {
+                        span: 4..7,
+                        name: "add",
+                    },
+                    type_ann: None,
+                },
+            ),
+            value: Lambda(
+                Lambda {
+                    span: 10..41,
+                    args: [
+                        Ident(
+                            BindingIdent {
+                                span: 11..20,
+                                id: Ident {
+                                    span: 11..20,
+                                    name: "a",
+                                },
+                                type_ann: Some(
+                                    Prim(
+                                        PrimType {
+                                            span: 14..20,
+                                            prim: Num,
+                                        },
+                                    ),
+                                ),
+                            },
+                        ),
+                        Ident(
+                            BindingIdent {
+                                span: 22..31,
+                                id: Ident {
+                                    span: 22..31,
+                                    name: "b",
+                                },
+                                type_ann: Some(
+                                    Prim(
+                                        PrimType {
+                                            span: 25..31,
+                                            prim: Num,
+                                        },
+                                    ),
+                                ),
+                            },
+                        ),
+                    ],
+                    body: Op(
+                        Op {
+                            span: 36..41,
+                            op: Add,
+                            left: Ident(
+                                Ident {
+                                    span: 36..37,
+                                    name: "a",
+                                },
+                            ),
+                            right: Ident(
+                                Ident {
+                                    span: 40..41,
+                                    name: "b",
+                                },
+                            ),
+                        },
+                    ),
+                    is_async: false,
+                },
+            ),
+        },
+    ],
+}

--- a/src/snapshots/crochet__parser__tests__type_annotations-4.snap
+++ b/src/snapshots/crochet__parser__tests__type_annotations-4.snap
@@ -1,0 +1,20 @@
+---
+source: src/parser.rs
+expression: "parse_type(\"Promise<number>\")"
+---
+TypeRef(
+    TypeRef {
+        span: 0..15,
+        name: "Promise",
+        type_params: Some(
+            [
+                Prim(
+                    PrimType {
+                        span: 8..14,
+                        prim: Num,
+                    },
+                ),
+            ],
+        ),
+    },
+)

--- a/src/snapshots/crochet__parser__tests__type_annotations-5.snap
+++ b/src/snapshots/crochet__parser__tests__type_annotations-5.snap
@@ -1,0 +1,60 @@
+---
+source: src/parser.rs
+expression: "parse(\"let p: Point = {x: 5, y: 10}\")"
+---
+Program {
+    body: [
+        Decl {
+            span: 0..28,
+            pattern: Ident(
+                BindingIdent {
+                    span: 4..12,
+                    id: Ident {
+                        span: 4..12,
+                        name: "p",
+                    },
+                    type_ann: Some(
+                        TypeRef(
+                            TypeRef {
+                                span: 7..12,
+                                name: "Point",
+                                type_params: None,
+                            },
+                        ),
+                    ),
+                },
+            ),
+            value: Obj(
+                Obj {
+                    span: 15..28,
+                    properties: [
+                        Property {
+                            span: 16..20,
+                            name: "x",
+                            value: Lit(
+                                Num(
+                                    Num {
+                                        span: 19..20,
+                                        value: "5",
+                                    },
+                                ),
+                            ),
+                        },
+                        Property {
+                            span: 22..27,
+                            name: "y",
+                            value: Lit(
+                                Num(
+                                    Num {
+                                        span: 25..27,
+                                        value: "10",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                },
+            ),
+        },
+    ],
+}

--- a/src/snapshots/crochet__parser__tests__type_annotations-6.snap
+++ b/src/snapshots/crochet__parser__tests__type_annotations-6.snap
@@ -1,0 +1,41 @@
+---
+source: src/parser.rs
+expression: "parse(\"let FOO: \\\"foo\\\" = \\\"foo\\\"\")"
+---
+Program {
+    body: [
+        Decl {
+            span: 0..22,
+            pattern: Ident(
+                BindingIdent {
+                    span: 4..14,
+                    id: Ident {
+                        span: 4..14,
+                        name: "FOO",
+                    },
+                    type_ann: Some(
+                        Lit(
+                            LitType {
+                                span: 9..14,
+                                lit: Str(
+                                    Str {
+                                        span: 9..14,
+                                        value: "foo",
+                                    },
+                                ),
+                            },
+                        ),
+                    ),
+                },
+            ),
+            value: Lit(
+                Str(
+                    Str {
+                        span: 17..22,
+                        value: "foo",
+                    },
+                ),
+            ),
+        },
+    ],
+}

--- a/src/snapshots/crochet__parser__tests__type_annotations-7.snap
+++ b/src/snapshots/crochet__parser__tests__type_annotations-7.snap
@@ -1,0 +1,29 @@
+---
+source: src/parser.rs
+expression: "parse_type(\"(number, string) => boolean\")"
+---
+Lam(
+    LamType {
+        span: 0..27,
+        args: [
+            Prim(
+                PrimType {
+                    span: 1..7,
+                    prim: Num,
+                },
+            ),
+            Prim(
+                PrimType {
+                    span: 9..15,
+                    prim: Str,
+                },
+            ),
+        ],
+        ret: Prim(
+            PrimType {
+                span: 20..27,
+                prim: Bool,
+            },
+        ),
+    },
+)

--- a/src/snapshots/crochet__parser__tests__type_annotations-8.snap
+++ b/src/snapshots/crochet__parser__tests__type_annotations-8.snap
@@ -1,0 +1,31 @@
+---
+source: src/parser.rs
+expression: "parse_type(\"{x: number, y: number}\")"
+---
+Object(
+    ObjectType {
+        span: 0..22,
+        props: [
+            TProp {
+                span: 1..10,
+                name: "x",
+                type_ann: Prim(
+                    PrimType {
+                        span: 4..10,
+                        prim: Num,
+                    },
+                ),
+            },
+            TProp {
+                span: 12..21,
+                name: "y",
+                type_ann: Prim(
+                    PrimType {
+                        span: 15..21,
+                        prim: Num,
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/src/snapshots/crochet__parser__tests__type_annotations-9.snap
+++ b/src/snapshots/crochet__parser__tests__type_annotations-9.snap
@@ -1,0 +1,46 @@
+---
+source: src/parser.rs
+expression: "parse_type(\"(A, B) => C | D\")"
+---
+Lam(
+    LamType {
+        span: 0..15,
+        args: [
+            TypeRef(
+                TypeRef {
+                    span: 1..2,
+                    name: "A",
+                    type_params: None,
+                },
+            ),
+            TypeRef(
+                TypeRef {
+                    span: 4..5,
+                    name: "B",
+                    type_params: None,
+                },
+            ),
+        ],
+        ret: Union(
+            UnionType {
+                span: 10..15,
+                types: [
+                    TypeRef(
+                        TypeRef {
+                            span: 10..11,
+                            name: "C",
+                            type_params: None,
+                        },
+                    ),
+                    TypeRef(
+                        TypeRef {
+                            span: 14..15,
+                            name: "D",
+                            type_params: None,
+                        },
+                    ),
+                ],
+            },
+        ),
+    },
+)

--- a/src/snapshots/crochet__parser__tests__type_annotations.snap
+++ b/src/snapshots/crochet__parser__tests__type_annotations.snap
@@ -1,0 +1,36 @@
+---
+source: src/parser.rs
+expression: "parse(\"let x: number = 5\")"
+---
+Program {
+    body: [
+        Decl {
+            span: 0..17,
+            pattern: Ident(
+                BindingIdent {
+                    span: 4..14,
+                    id: Ident {
+                        span: 4..14,
+                        name: "x",
+                    },
+                    type_ann: Some(
+                        Prim(
+                            PrimType {
+                                span: 7..13,
+                                prim: Num,
+                            },
+                        ),
+                    ),
+                },
+            ),
+            value: Lit(
+                Num(
+                    Num {
+                        span: 16..17,
+                        value: "5",
+                    },
+                ),
+            ),
+        },
+    ],
+}


### PR DESCRIPTION
This fixes #30.

TODO:
- [x] union types
- [x] object types
- [x] proper precedence - e.g. `(A, B) => C | D`