### PR TITLE
Use explicit type annotations to generate type constraints

### DIFF
--- a/src/codegen/d_ts.rs
+++ b/src/codegen/d_ts.rs
@@ -356,12 +356,14 @@ pub fn build_type(
                 sym: JsWord::from(name.to_owned()),
                 optional: false,
             }),
-            type_params: Some(TsTypeParamInstantiation {
-                span: DUMMY_SP,
-                params: type_params
-                    .iter()
-                    .map(|ty| Box::from(build_type(ty, None, None)))
-                    .collect(),
+            type_params: type_params.clone().map(|params| {
+                TsTypeParamInstantiation {
+                    span: DUMMY_SP,
+                    params: params
+                        .iter()
+                        .map(|ty| Box::from(build_type(ty, None, None)))
+                        .collect(),
+                }
             }),
         }),
     }

--- a/src/infer/constraint_solver.rs
+++ b/src/infer/constraint_solver.rs
@@ -71,23 +71,29 @@ fn unifies(c: &Constraint, ctx: &Context) -> Subst {
         (
             Type::Alias(AliasType {
                 name: name1,
-                type_params: vars1,
+                type_params: type_params1,
                 ..
             }),
             Type::Alias(AliasType {
                 name: name2,
-                type_params: vars2,
+                type_params: type_params2,
                 ..
             }),
         ) if name1 == name2 => {
             // TODO: throw if vars1 and vars2 have different lengths
-            let cs: Vec<_> = vars1
-                .iter()
-                .zip(vars2)
-                .map(|(a, b)| Constraint {
-                    types: (a.clone(), b.clone()),
-                })
-                .collect();
+            let cs: Vec<_> = match (type_params1, type_params2) {
+                (Some(params1), Some(params2)) => {
+                    params1
+                        .iter()
+                        .zip(params2)
+                        .map(|(a, b)| Constraint {
+                            types: (a.clone(), b.clone()),
+                        })
+                        .collect()
+                },
+                (None, None) => vec![],
+                _ => panic!("mismatch in type params"),
+            };
             unify_many(&cs, ctx)
         }
 

--- a/src/infer/constraint_solver.rs
+++ b/src/infer/constraint_solver.rs
@@ -161,7 +161,7 @@ fn unify_many(cs: &[Constraint], ctx: &Context) -> Subst {
     }
 }
 
-fn is_subtype(t1: &Type, t2: &Type) -> bool {
+pub fn is_subtype(t1: &Type, t2: &Type) -> bool {
     match (t1, t2) {
         (Type::Lit(LitType { lit, .. }), Type::Prim(PrimType { prim, .. })) => match (lit, prim) {
             (Lit::Num(_), Primitive::Num) => true,

--- a/src/infer/context.rs
+++ b/src/infer/context.rs
@@ -126,7 +126,7 @@ impl Context {
             ty,
         }
     }
-    pub fn alias(&self, name: &str, type_params: Vec<Type>) -> Type {
+    pub fn alias(&self, name: &str, type_params: Option<Vec<Type>>) -> Type {
         Type::Alias(types::AliasType {
             id: self.fresh_id(),
             frozen: false,

--- a/src/infer/substitutable.rs
+++ b/src/infer/substitutable.rs
@@ -82,7 +82,9 @@ impl Substitutable for Type {
                     id: id.to_owned(),
                     frozen: frozen.to_owned(),
                     name: name.to_owned(),
-                    type_params: type_params.iter().map(|ty| ty.apply(sub)).collect(),
+                    type_params: type_params.clone().map(|params| {
+                        params.iter().map(|ty| ty.apply(sub)).collect()
+                    }),
                 }),
             },
         }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -61,6 +61,20 @@ fn infer_fn_param() {
 }
 
 #[test]
+fn infer_fn_with_param_types() {
+    assert_eq!(
+        infer("(a: 5, b: 10) => a + b"),
+        "(5, 10) => number"
+    );
+}
+
+#[test]
+#[should_panic = "unification failed"]
+fn infer_fn_with_incorrect_param_types() {
+    infer("(a: string, b: boolean) => a + b");
+}
+
+#[test]
 fn infer_fn_param_used_with_multiple_other_params() {
     assert_eq!(
         infer("(f, x, y) => f(x) + f(y)"),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -16,7 +16,6 @@ fn infer(input: &str) -> String {
 }
 
 fn infer_prog(src: &str) -> (Program, Env) {
-    let env: Env = HashMap::new();
     let result = parser().parse(src);
     let prog = match result {
         Ok(prog) => prog,
@@ -27,6 +26,7 @@ fn infer_prog(src: &str) -> (Program, Env) {
     };
     // println!("prog = {:#?}", &prog);
     // let prog = token_parser(&spans).parse(tokens).unwrap();
+    let env: Env = HashMap::new();
     let env = crochet::infer::infer_prog(env, &prog);
 
     (prog, env)
@@ -377,4 +377,23 @@ fn codegen_async_math() {
     let result = codegen_d_ts(&program, &env);
 
     insta::assert_snapshot!(result, @"export declare const add: (a: () => Promise<number>, b: () => Promise<number>) => Promise<number>;\n");
+}
+
+#[test]
+fn infer_let_decl_with_type_ann() {
+    let src = "let x: number = 10";
+    let (_, env) = infer_prog(src);
+
+    let result = format!("{}", env.get("x").unwrap());
+    assert_eq!(result, "number");
+}
+
+#[test]
+#[should_panic = "value is not a subtype of decl's declared type"]
+fn infer_let_decl_with_incorrect_type_ann() {
+    let src = "let x: string = 10";
+    let (_, env) = infer_prog(src);
+
+    let result = format!("{}", env.get("x").unwrap());
+    assert_eq!(result, "number");
 }


### PR DESCRIPTION
- [x] type annotations on lambda params
- [x] type annotations on `let-in` expressions
- [x] type annotations on top-level `let` declarations 